### PR TITLE
Migration to Vuex mapGetters style from Vue component direct access Vuex state

### DIFF
--- a/components/organisms/AppHeader.vue
+++ b/components/organisms/AppHeader.vue
@@ -6,12 +6,13 @@
       v-if="showEditHeaderNav"
       :showPostArticleLink="showPostArticleLink"
       :showEditArticleLink="showEditArticleLink"/>
-    <header-session-links v-if="!this.$store.state.user.loggedIn"/>
-    <header-user-logged-in-items v-if="this.$store.state.user.loggedIn"/>
+    <header-session-links v-if="!loggedIn"/>
+    <header-user-logged-in-items v-else />
   </header>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import DefaultHeaderNav from '../molecules/DefaultHeaderNav'
 import EditHeaderNav from '../molecules/EditHeaderNav'
 import HeaderSessionLinks from '../atoms/HeaderSessionLinks'
@@ -41,6 +42,9 @@ export default {
     EditHeaderNav,
     HeaderSessionLinks,
     HeaderUserLoggedInItems
+  },
+  computed: {
+    ...mapGetters('user', ['loggedIn'])
   }
 }
 </script>

--- a/pages/_user/articles/_id.vue
+++ b/pages/_user/articles/_id.vue
@@ -1,8 +1,9 @@
 <template>
-  <article-detail :article="this.$store.state.article.article"/>
+  <article-detail :article="article"/>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import ArticleDetail from '~/components/pages/ArticleDetail'
 
 export default {
@@ -19,6 +20,9 @@ export default {
     store.dispatch('article/setUserInfoToArticle', { userInfo })
     store.dispatch('article/setLikesCountToArticle', { likesCount })
     store.dispatch('article/setAlisTokenToArticle', { alisToken })
+  },
+  computed: {
+    ...mapGetters('article', ['article'])
   }
 }
 </script>

--- a/pages/me/articles/public/_articleId/index.vue
+++ b/pages/me/articles/public/_articleId/index.vue
@@ -1,8 +1,9 @@
 <template>
-  <public-article :article="this.$store.state.article.article"/>
+  <public-article :article="article"/>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import PublicArticle from '~/components/pages/PublicArticle'
 
 export default {
@@ -19,6 +20,9 @@ export default {
     store.dispatch('article/setUserInfoToArticle', { userInfo })
     store.dispatch('article/setLikesCountToArticle', { likesCount })
     store.dispatch('article/setAlisTokenToArticle', { alisToken })
+  },
+  computed: {
+    ...mapGetters('article', ['article'])
   }
 }
 </script>

--- a/store/modules/article.js
+++ b/store/modules/article.js
@@ -31,6 +31,7 @@ const state = () => ({
 })
 
 const getters = {
+  article: (state) => state.article,
   allArticles: (state) => state.articles,
   newArticles: (state) => state.newArticles,
   publicArticles: (state) => state.publicArticles,

--- a/store/modules/user.js
+++ b/store/modules/user.js
@@ -4,7 +4,9 @@ const state = () => ({
   loggedIn: false
 })
 
-const getters = {}
+const getters = {
+  loggedIn: (state) => state.loggedIn
+}
 
 const actions = {}
 


### PR DESCRIPTION
## Description

Prohibited direct access to Vuex state and changed it to access from getter.
Tags to be deleted are not supported.