### PR TITLE
Rollback lodash-es to lodash

### DIFF
--- a/components/pages/CreateArticle.vue
+++ b/components/pages/CreateArticle.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { debounce } from 'lodash-es'
+import { debounce } from 'lodash'
 import { mapActions, mapGetters } from 'vuex'
 import AppHeader from '../organisms/AppHeader'
 import ArticleEditor from '../atoms/ArticleEditor'

--- a/components/pages/EditDraftArticle.vue
+++ b/components/pages/EditDraftArticle.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { debounce } from 'lodash-es'
+import { debounce } from 'lodash'
 import { mapGetters, mapActions } from 'vuex'
 import AppHeader from '../organisms/AppHeader'
 import ArticleEditor from '../atoms/ArticleEditor'

--- a/components/pages/EditPublicArticle.vue
+++ b/components/pages/EditPublicArticle.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { debounce } from 'lodash-es'
+import { debounce } from 'lodash'
 import { mapGetters, mapActions } from 'vuex'
 import AppHeader from '../organisms/AppHeader'
 import ArticleEditor from '../atoms/ArticleEditor'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.1.1",
     "axios": "^0.17.1",
-    "lodash-es": "^4.17.7",
+    "lodash": "^4.17.5",
     "medium-editor": "^5.23.3",
     "moment": "^2.21.0",
     "normalize.css": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3808,10 +3808,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.7:
-  version "4.17.7"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.7.tgz#db240a3252c3dd8360201ac9feef91ac977ea856"
-
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -3893,7 +3889,7 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lo
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.17.2:
+lodash@^4.17.2, lodash@^4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
## About

Nuxt's webpack config is ignore `node_modules`.
So, lodash-es in ESM format will be a build error.
As a countermeasure, I rolled back lodash-es to lodash.