### PR TITLE
Migrate to serverless-application from mock api

### DIFF
--- a/components/molecules/ArticleCardContentData.vue
+++ b/components/molecules/ArticleCardContentData.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="area-data">
-    <article-card-content-data-profile-icon :user="article.user"/>
+    <!-- <article-card-content-data-profile-icon :user="article.user"/>
     <article-card-content-data-username :username="article.user.user_display_name"/>
-    <article-card-content-data-created-at :createdAt="article.created_at"/>
+    <article-card-content-data-created-at :createdAt="article.created_at"/> -->
   </div>
 </template>
 

--- a/components/molecules/EditHeaderNav.vue
+++ b/components/molecules/EditHeaderNav.vue
@@ -81,14 +81,23 @@ export default {
       }
     },
     async publish() {
+      const { articleId } = this
       const article = {
-        overview: this.body.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, ''),
-        eye_catch_url: this.thumbnail
+        title: this.title,
+        body: this.body
+          .replace(/<p class="medium-insert-active">[\s\S]*/, '')
+          .replace(/<div class="medium-insert-buttons"[\s\S]*/, '')
       }
-      const { articleId } = this.$route.params
+      await this.putDraftArticle({ article, articleId })
+
+      article.eye_catch_url = this.thumbnail
+      article.overview = this.body.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, '').replace('+', '')
 
       try {
-        if (location.href.includes('/me/articles/draft')) {
+        if (
+          location.href.includes('/me/articles/draft') ||
+          location.href.includes('/me/articles/new')
+        ) {
           await this.publishDraftArticle({ article, articleId })
         } else if (location.href.includes('/me/articles/public')) {
           await this.publishPublicArticle({ article, articleId })
@@ -123,10 +132,24 @@ export default {
         }
       })
     },
-    ...mapActions('article', ['updateThumbnail', 'publishDraftArticle', 'publishPublicArticle', 'unpublishPublicArticle'])
+    ...mapActions('article', [
+      'updateThumbnail',
+      'publishDraftArticle',
+      'publishPublicArticle',
+      'unpublishPublicArticle',
+      'putDraftArticle'
+    ])
   },
   computed: {
-    ...mapGetters('article', ['body', 'thumbnail', 'suggestedThumbnails', 'isSaving', 'isSaved']),
+    ...mapGetters('article', [
+      'articleId',
+      'title',
+      'body',
+      'thumbnail',
+      'suggestedThumbnails',
+      'isSaving',
+      'isSaved'
+    ]),
     saveStatus() {
       if (this.isSaved) {
         return 'Saved'

--- a/components/molecules/LoginModalForm.vue
+++ b/components/molecules/LoginModalForm.vue
@@ -31,6 +31,8 @@
       </form>
     </div>
     <div class="modal-footer">
+      <p class="error-message">{{ errorMessage }}</p>
+
       <p class="agreement-confirmation">
         <nuxt-link to="#">利用規約</nuxt-link>、<nuxt-link to="#">プライバシーポリシー</nuxt-link>に同意して
       </p>
@@ -52,6 +54,11 @@ import { mapActions, mapGetters } from 'vuex'
 import { required, minLength } from 'vuelidate/lib/validators'
 
 export default {
+  data() {
+    return {
+      errorMessage: ''
+    }
+  },
   computed: {
     showErrorInvalidPassword() {
       return this.loginModal.formError.password && !this.$v.loginModal.formData.password.minLength
@@ -254,6 +261,12 @@ export default {
       color: #6e6e6e;
       cursor: default;
     }
+  }
+
+  .error-message {
+    color: #f06273;
+    font-size: 12px;
+    width: 100%;
   }
 
   .for-signup-user,

--- a/components/pages/ArticleDetail.vue
+++ b/components/pages/ArticleDetail.vue
@@ -8,7 +8,7 @@
       <article-tags :tags="article.tags"/>
       <article-footer-actions :likesCount="article.likesCount"/>
       <article-side-actions :likesCount="article.likesCount"/>
-      <author-info :article="article"/>
+      <!-- <author-info :article="article"/> -->
       <article-comments :comments="article.comments"/>
     </div>
     <related-articles :articles="article.relatedArticles"/>

--- a/components/pages/CreateArticle.vue
+++ b/components/pages/CreateArticle.vue
@@ -31,8 +31,8 @@ export default {
     ...mapActions('article', ['postNewArticle', 'putDraftArticle', 'setIsSaving', 'setIsSaved']),
     postOrPutArticle: debounce(async function() {
       const article = {
-        title: this.title,
-        body: this.body
+        title: this.title + ' ',
+        body: this.body + ' '
       }
       this.setIsSaving({ isSaving: true })
       if (this.isPosted) {

--- a/pages/_user/articles/_id.vue
+++ b/pages/_user/articles/_id.vue
@@ -11,15 +11,16 @@ export default {
     ArticleDetail
   },
   async fetch({ store, params }) {
-    const { id: articleId, user: userId } = params
+    const { id: articleId } = params
+    // const { id: articleId, user: userId } = params
     await store.dispatch('article/getArticleDetail', { articleId })
-    await store.dispatch('article/getUserInfo', { userId })
-    await store.dispatch('article/getLikesCountOfArticle', { articleId })
-    await store.dispatch('article/getAlisToken', { articleId })
-    const { userInfo, likesCount, alisToken } = store.state.article
-    store.dispatch('article/setUserInfoToArticle', { userInfo })
-    store.dispatch('article/setLikesCountToArticle', { likesCount })
-    store.dispatch('article/setAlisTokenToArticle', { alisToken })
+    // await store.dispatch('article/getUserInfo', { userId })
+    // await store.dispatch('article/getLikesCountOfArticle', { articleId })
+    // await store.dispatch('article/getAlisToken', { articleId })
+    // const { userInfo, likesCount, alisToken } = store.state.article
+    // store.dispatch('article/setUserInfoToArticle', { userInfo })
+    // store.dispatch('article/setLikesCountToArticle', { likesCount })
+    // store.dispatch('article/setAlisTokenToArticle', { alisToken })
   },
   computed: {
     ...mapGetters('article', ['article'])

--- a/pages/articles/new.vue
+++ b/pages/articles/new.vue
@@ -11,7 +11,8 @@ export default {
   },
   async fetch({ store }) {
     await store.dispatch('article/getNewPagesArticles')
-    const { newArticles: articles } = store.state.article
+    const { articles } = store.state.article
+    // const { newArticles: articles } = store.state.article
     await store.dispatch('article/getUserInfos', { articles })
     await store.dispatch('article/getAlisTokens', { articles })
     const { userInfos, alisTokens } = store.state.article

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,3 +1,7 @@
-export default function({ $axios }) {
-
+export default ({ $axios }) => {
+  if (process.browser) {
+    const currentUser = localStorage.getItem(`CognitoIdentityServiceProvider.${process.env.CLIENT_ID}.LastAuthUser`)
+    const token = localStorage.getItem(`CognitoIdentityServiceProvider.${process.env.CLIENT_ID}.${currentUser}.idToken`)
+    $axios.setToken(token)
+  }
 }

--- a/store/modules/article.js
+++ b/store/modules/article.js
@@ -51,7 +51,7 @@ const actions = {
     commit(types.SET_ARTICLES, { articles })
   },
   async getNewPagesArticles({ commit }) {
-    const articles = await this.$axios.$get('/articles/new')
+    const { Items: articles } = await this.$axios.$get('/articles/recent', { params: { limit: 20 } })
     commit(types.SET_NEW_ARTICLES, { articles })
   },
   async getUserInfo({ commit }, { userId }) {
@@ -87,8 +87,12 @@ const actions = {
     commit(types.SET_ARTICLE, { article })
   },
   async getArticleDetail({ commit }, { articleId }) {
-    const article = await this.$axios.$get(`/articles/${articleId}`)
-    commit(types.SET_ARTICLE_DETAIL, { article })
+    try {
+      const article = await this.$axios.$get(`/articles/${articleId}`)
+      commit(types.SET_ARTICLE_DETAIL, { article })
+    } catch (error) {
+      Promise.reject(error)
+    }
   },
   async getPublicArticleDetail({ commit }, { articleId }) {
     const article = await this.$axios.$get(`/me/articles/public/${articleId}`)
@@ -103,7 +107,7 @@ const actions = {
     commit(types.SET_ARTICLE_ID, { articleId })
   },
   async putDraftArticle({ commit }, { article, articleId }) {
-    await this.$axios.$put(`/me/articles/public/${articleId}/edit`, article)
+    await this.$axios.$put(`/me/articles/${articleId}/drafts`, article)
   },
   async putPublicArticle({ commit }, { article, articleId }) {
     await this.$axios.$put(`/me/articles/public/${articleId}/edit`, article)
@@ -121,7 +125,7 @@ const actions = {
     commit(types.SET_DRAFT_ARTICLES, { articles })
   },
   async publishDraftArticle({ commit }, { article, articleId }) {
-    await this.$axios.$put(`/me/articles/drafts/${articleId}/publish`, article)
+    await this.$axios.$put(`/me/articles/${articleId}/drafts/publish`, article)
   },
   async publishPublicArticle({ commit }, { article, articleId }) {
     await this.$axios.$put(`/me/articles/public/${articleId}/edit/publish`, article)
@@ -167,6 +171,19 @@ const actions = {
   },
   setIsSaved({ commit }, { isSaved }) {
     commit(types.SET_IS_SAVED, { isSaved })
+  },
+  async postArticleImage({ commit }, { articleId, articleImage, imageContentType }) {
+    try {
+      const config = {
+        headers: { 'content-type': imageContentType }
+      }
+      const result = await this.$axios.$post(`/me/articles/${articleId}/images`,
+        { article_image: articleImage }, config
+      )
+      return result
+    } catch (error) {
+      Promise.reject(error)
+    }
   }
 }
 


### PR DESCRIPTION
## 主な変更点

- 画像の投稿
    - 重複アップロード対応はまだ
- 下書き記事の作成、更新、投稿
    - Overviewの形式が若干汚いまま
- 新着記事の表示
    - まだ紐づけ出来ない部分（ユーザー情報など）に関しては紐づけていない
- axiosにauthTokenの付与
- 記事詳細の取得
    - /articles/:article_id
    - まだ紐づけ出来ない部分（ユーザー情報など）に関しては紐づけていない
