### PR TITLE
Add title meta template

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,6 +4,16 @@
   </div>
 </template>
 
+<script>
+export default {
+  head() {
+    return {
+      titleTemplate: '%s | ALISMedia'
+    }
+  }
+}
+</script>
+
 <style>
 @import 'normalize.css';
 


### PR DESCRIPTION
## About

Using the function of vue-meta, we gave the title template.
This is part of the 2018/04/06 review.

## Refs

- https://nuxtjs.org/guide/views#html-head
- https://github.com/declandewet/vue-meta