### PR TITLE
Add proxyHeaders option to axios

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -26,7 +26,8 @@ module.exports = {
     '~/plugins/vuelidate'
   ],
   axios: {
-    baseURL: process.env.BASE_URL
+    baseURL: process.env.BASE_URL,
+    proxyHeaders: false
   },
   srcDir: 'app',
   router: {


### PR DESCRIPTION
https://axios.nuxtjs.org/options.html#proxyheaders
NOTE: If directing requests at a url protected by CloudFlare's CDN you should set this to false to prevent CloudFlare from mistakenly detecting a reverse proxy loop and returning a 403 error.