### PR TITLE
ALIS-596: Add bottom space when there is no self introduction

### DIFF
--- a/app/components/atoms/AuthorInfo.vue
+++ b/app/components/atoms/AuthorInfo.vue
@@ -23,7 +23,7 @@
       </p>
     </div>
     <div class="area-self-introduction">
-      <p class="self-introduction">
+      <p class="self-introduction" :class="{ 'add-bottom-space': user.self_introduction.trim() === '' }">
         {{ user.self_introduction }}
       </p>
     </div>
@@ -98,6 +98,10 @@ export default {
     color: #030303;
     font-size: 14px;
     line-height: 24px;
+
+    &.add-bottom-space {
+      padding-bottom: 4px;
+    }
   }
 }
 


### PR DESCRIPTION
## Before
<img width="680" alt="2018-04-20 19 30 56" src="https://user-images.githubusercontent.com/13657589/39046527-73c67c44-44d1-11e8-96cc-effdf302c8c8.png">

## After
<img width="682" alt="2018-04-20 19 40 36" src="https://user-images.githubusercontent.com/13657589/39046879-c1ec7b48-44d2-11e8-927e-764bb3d86d90.png">
