### PR TITLE
ALIS-732: Fix position of user settings icon on mobile

### DIFF
--- a/app/components/atoms/UserArticleListUserInfo.vue
+++ b/app/components/atoms/UserArticleListUserInfo.vue
@@ -162,7 +162,7 @@ export default {
 
     .profile-edit {
       bottom: 10px;
-      right: -300px;
+      right: -260px;
       cursor: pointer;
     }
   }
@@ -194,6 +194,12 @@ export default {
 @media screen and (max-width: 320px) {
   .area-user-info-container {
     grid-template-columns: 1fr 60px 200px 1fr;
+  }
+
+  .area-profile-icon {
+    .profile-edit {
+      right: -220px;
+    }
   }
 }
 </style>


### PR DESCRIPTION
# Before
## iPhone 6/7/8
<img width="402" alt="2018-04-21 14 09 50" src="https://user-images.githubusercontent.com/13657589/39080636-d029a4f6-456d-11e8-8cd0-094e4869b4d5.png">

## iPhone 5
<img width="339" alt="2018-04-21 14 10 03" src="https://user-images.githubusercontent.com/13657589/39080638-dfbafc76-456d-11e8-9217-cfa200c5f9c1.png">

# After
## iPhone 6/7/8
<img width="406" alt="2018-04-21 14 09 19" src="https://user-images.githubusercontent.com/13657589/39080650-29233342-456e-11e8-9167-02ad6f268470.png">

## iPhone 5
<img width="348" alt="2018-04-21 14 09 32" src="https://user-images.githubusercontent.com/13657589/39080652-2fc7695c-456e-11e8-9063-4ac304d7eaa6.png">


