### PR TITLE
Disable space-before-function-paren

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
   plugins: ['html'],
   // add your custom rules here
   rules: {
-    'space-before-function-paren': ['error', 'never']
+    'space-before-function-paren': 0
   },
   globals: {}
 }

--- a/app/components/atoms/ArticleEditor.vue
+++ b/app/components/atoms/ArticleEditor.vue
@@ -119,7 +119,7 @@ export default {
         },
         spellcheck: false
       })
-      /* eslint-disable space-before-function-paren */
+
       editorElement.subscribe('editableInput', (event, editable) => {
         window.document.onkeydown = async (event) => {
           if (event.key === 'Enter') {
@@ -193,7 +193,7 @@ export default {
     },
     async onInputBody() {
       const images = Array.from(document.querySelectorAll('.area-body figure img'))
-      /* eslint-disable space-before-function-paren */
+
       await Promise.all(
         images.map(async (img) => {
           this.setIsSaving({ isSaving: true })

--- a/app/components/molecules/EditHeaderNav.vue
+++ b/app/components/molecules/EditHeaderNav.vue
@@ -84,7 +84,7 @@ export default {
     },
     async updateArticleData() {
       const images = Array.from(document.querySelectorAll('.area-body figure img'))
-      /* eslint-disable space-before-function-paren */
+
       await Promise.all(
         images.map(async (img) => {
           this.setIsSaving({ isSaving: true })

--- a/app/components/molecules/ProfileSettingsModalForm.vue
+++ b/app/components/molecules/ProfileSettingsModalForm.vue
@@ -117,7 +117,7 @@ export default {
         return
       }
       const reader = new FileReader()
-      /* eslint-disable space-before-function-paren */
+
       reader.onload = async (e) => {
         try {
           const base64Image = e.target.result

--- a/app/plugins/axios.js
+++ b/app/plugins/axios.js
@@ -1,4 +1,4 @@
-/* eslint-disable space-before-function-paren */
+
 export default async ({ $axios, store, env }) => {
   store.dispatch('user/initCognito')
   try {

--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -1,4 +1,4 @@
-/* eslint-disable space-before-function-paren */
+
 import * as types from '../mutation-types'
 
 const namespaced = true

--- a/app/store/modules/presentation.js
+++ b/app/store/modules/presentation.js
@@ -1,4 +1,4 @@
-/* eslint-disable space-before-function-paren */
+
 import * as types from '../mutation-types'
 
 const namespaced = true

--- a/app/store/modules/user.js
+++ b/app/store/modules/user.js
@@ -1,4 +1,4 @@
-/* eslint-disable space-before-function-paren */
+
 import { BigNumber } from 'bignumber.js'
 import * as types from '../mutation-types'
 import CognitoSDK from '~/utils/cognito-sdk'

--- a/app/utils/showEmbedTweet.js
+++ b/app/utils/showEmbedTweet.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-/* eslint-disable space-before-function-paren */
+
 export default ({ $axios }) => {
   document.querySelectorAll('[data-alis-iframely-url]').forEach(async (element) => {
     const { alisIframelyUrl } = element.dataset


### PR DESCRIPTION
## About
Temporarily deleted "space-before-function-paren" of ESLint.
This is the purpose of resolving conflicts with `prettier`.