### PR TITLE
ALIS-979: Avoid CORS errors using proxy module

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+const isDevelopment = process.env.NODE_ENV === 'development'
+
 module.exports = {
   /*
   ** Headers of the page
@@ -47,8 +49,15 @@ module.exports = {
     { src: '~plugins/gtm.js', ssr: false }
   ],
   axios: {
-    baseURL: process.env.BASE_URL,
-    proxyHeaders: false
+    prefix: '/api',
+    proxyHeaders: false,
+    proxy: isDevelopment
+  },
+  proxy: !isDevelopment ? {} : {
+    '/api': {
+      target: process.env.BASE_URL,
+      pathRewrite: { '^/api': '/' }
+    }
   },
   srcDir: 'app',
   router: {
@@ -57,9 +66,6 @@ module.exports = {
   render: {
     gzip: false
   },
-  proxy: process.env.NODE_ENV !== 'localhost' ? [] : [
-    `https://${process.env.DOMAIN}/api/`
-  ],
   build: {
     publicPath: `https://${process.env.DOMAIN}/d/nuxt/dist/`,
     /*

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "vuex-toast": "^0.1.3"
   },
   "devDependencies": {
-    "@nuxtjs/proxy": "^1.2.4",
     "axios-mock-adapter": "^1.10.0",
     "babel-eslint": "^7.2.3",
     "cross-env": "^5.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,13 +33,6 @@
   dependencies:
     http-proxy-middleware "^0.17.4"
 
-"@nuxtjs/proxy@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-1.2.4.tgz#41aafac58854f14e28aed17238936bb6404e6071"
-  dependencies:
-    consola "^1.1.4"
-    http-proxy-middleware "^0.18.0"
-
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -1368,10 +1361,6 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
-ci-info@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
-
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -1605,15 +1594,6 @@ connect@^3.6.5:
     parseurl "~1.3.2"
     utils-merge "1.0.1"
 
-consola@^1.1.4:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/consola/-/consola-1.3.0.tgz#b5effe41c4ecdce971d79268d72b8f9bde0a8c7a"
-  dependencies:
-    chalk "^2.3.2"
-    figures "^2.0.0"
-    lodash "^4.17.5"
-    std-env "^1.1.0"
-
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -1720,6 +1700,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-env@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.6.tgz#0dc05caf945b24e4b9e3b12871fe0e858d08b38d"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -3324,15 +3311,6 @@ http-proxy-middleware@^0.17.4:
     lodash "^4.17.2"
     micromatch "^2.3.11"
 
-http-proxy-middleware@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
-  dependencies:
-    http-proxy "^1.16.2"
-    is-glob "^4.0.0"
-    lodash "^4.17.5"
-    micromatch "^3.1.9"
-
 http-proxy@^1.16.2:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
@@ -3536,12 +3514,6 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-ci@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
-  dependencies:
-    ci-info "^1.0.0"
-
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -3735,7 +3707,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -4248,7 +4220,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4, micromatch@^3.1.9:
+micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -6530,12 +6502,6 @@ statuses@~1.3.1:
 statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-
-std-env@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-1.3.0.tgz#8ce754a401a61f1ac49c8eb55f2a8c0c63d54954"
-  dependencies:
-    is-ci "^1.1.0"
 
 stdout-stream@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## 概要
localで開発する際にCORS制約を回避するために、ブラウザから見た時に、localhost:3000/api/~ でAPIコールできるようにする（localhost:3000 から localhost:3000/api を叩いているのでクロスドメイン制約に引っかからない）ようにしたかった。

1. 環境変数でBaseUrlをlocalhost:3000/apiにする
2. localhost:3000/api アクセス時に https://{DOMAIN}/api に変換してアクセスできるようにする(proxy)

をnuxt.jsのproxy moduleを使って実現した。

## 環境変数
特に変更なし（正確にはBaseUrlなどを変えているのだが、コマンドで直接渡してしまうので影響なし）

## 影響範囲(ユーザ)
* 開発者
  * しかしインターフェースは変わらない

## 影響範囲(システム) 
- フロントエンド


## 技術的変更点概要
* `yarn dev`を実行した際に`BASE_URL`と`NODE_ENV`を環境変数として渡すように修正。
* `NODE_ENV`がlocalhostの場合は、自分自身（localhost:3000）の/apiのパスをSTGドメインにproxyする

## DBやDBへのクエリに対する変更
変更なし

## ブロックチェーンへの影響
* ブロックチェーンの参照なし

## 個人情報の取り扱いに変更のあるリリースか
* なし