### PR TITLE
Implement proxy config only development build

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,6 @@
-module.exports = {
+const isProduction = process.env.NODE_ENV === 'production'
+
+const nuxtConfig = {
   /*
   ** Headers of the page
   */
@@ -110,3 +112,19 @@ module.exports = {
     DOMAIN: process.env.DOMAIN
   }
 }
+
+if (!isProduction) {
+  nuxtConfig.axios = {
+    prefix: '/api',
+    proxyHeaders: false,
+    proxy: true
+  }
+  nuxtConfig.proxy = {
+    '/api': {
+      target: process.env.BASE_URL,
+      pathRewrite: { '^/api': '/' }
+    }
+  }
+}
+
+module.exports = nuxtConfig


### PR DESCRIPTION
## About

Add proxy settings.

## Note

- Development with enabled --disable-web-security is way too fragile
- I heard that the CORS configuration is not in a state where it can be immediately activated on the server side
- Set proxy as the minimum measure