### PR TITLE
Through drop event to medium insert buttons

### DIFF
--- a/app/components/atoms/ArticleEditor.vue
+++ b/app/components/atoms/ArticleEditor.vue
@@ -384,6 +384,7 @@ export default {
     preventDragoverImage(event) {
       event.preventDefault()
       event.stopPropagation()
+      this.$refs.editable.classList.add('is-dragging-item')
       setTimeout(() => {
         this.targetDOM = $('.medium-editor-dragover')
       }, 10)
@@ -392,10 +393,12 @@ export default {
     preventDropImage(event) {
       event.preventDefault()
       event.stopPropagation()
+      this.$refs.editable.classList.remove('is-dragging-item')
       this.insertDragImage(event.dataTransfer.files)
       return false
     },
     insertDragImage(files) {
+      this.$refs.editable.classList.remove('is-dragging-item')
       if (this.targetDOM[0].classList.value.includes('area-body')) return
       const [target] = files
       const MAX_UPLOAD = 4.5 * 1024 * 1024 // 4.5 MB
@@ -414,10 +417,20 @@ export default {
     },
     preventDragAndDrop(element) {
       element.addEventListener(
+        'dragout',
+        (e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          this.$refs.editable.classList.remove('is-dragging-item')
+        },
+        false
+      )
+      element.addEventListener(
         'drop',
         (e) => {
           e.preventDefault()
           e.stopPropagation()
+          this.$refs.editable.classList.remove('is-dragging-item')
         },
         false
       )
@@ -426,6 +439,7 @@ export default {
         (e) => {
           e.preventDefault()
           e.stopPropagation()
+          this.$refs.editable.classList.add('is-dragging-item')
         },
         false
       )
@@ -546,6 +560,16 @@ export default {
   .area-editor-container {
     grid-template-columns: 1fr;
     display: none;
+  }
+}
+</style>
+
+<style lang="scss">
+.area-body {
+  &.is-dragging-item {
+    .medium-insert-buttons {
+      pointer-events: none;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## About

When uploading by Drag-and-Drop, the presence of medium-insert-button disturbs.
But, because it is in the range of Medium Editor (outside of Vue), it is difficult to display in JavaScript / Vue template.

So, we decided to switch display by simple classList operation and CSS.