### PR TITLE
Create nuxt.config.development.js and use it

### DIFF
--- a/nuxt.config.development.js
+++ b/nuxt.config.development.js
@@ -1,0 +1,16 @@
+const nuxtConfig = require('./nuxt.config.js')
+
+nuxtConfig.axios = {
+  prefix: '/api',
+  proxyHeaders: false,
+  proxy: true
+}
+
+nuxtConfig.proxy = {
+  '/api': {
+    target: process.env.BASE_URL,
+    pathRewrite: { '^/api': '/' }
+  }
+}
+
+module.exports = nuxtConfig

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "y-temp4 <y.temp4@gmail.com>",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development nuxt",
+    "dev": "cross-env NODE_ENV=development nuxt --config nuxt.config.development.js",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",


### PR DESCRIPTION
## about

開発環境用の nuxt.config.development.js を作成し、 `yarn dev` の時に限定してそちらの設定ファイルを利用するように変更しました。