### PR TITLE
ALIS-2107：fix behavior of title input

### DIFF
--- a/app/components/atoms/ArticleEditor/ArticleTitleInput.vue
+++ b/app/components/atoms/ArticleEditor/ArticleTitleInput.vue
@@ -25,8 +25,7 @@ export default {
       this.$emit('keyup', event.target.value)
     },
     moveToBody(event) {
-      let textarea = document.getElementsByTagName('textarea')[0]
-      let cursorPosition = textarea.selectionStart
+      const cursorPosition = this.$el.selectionStart
       if (event.target.value.length === cursorPosition) {
         this.$emit('focus-trigger')
       }

--- a/app/components/atoms/ArticleEditor/ArticleTitleInput.vue
+++ b/app/components/atoms/ArticleEditor/ArticleTitleInput.vue
@@ -6,7 +6,8 @@
     spellcheck="false"
     maxlength="255"
     :value="value"
-    @input="handleInput"
+    @keyup="handleInput"
+    @keydown.enter.prevent="moveToBody"
     wrap="soft"
   ></textarea>
 </template>
@@ -21,7 +22,14 @@ export default {
   },
   methods: {
     handleInput(event) {
-      this.$emit('input', event.target.value)
+      this.$emit('keyup', event.target.value)
+    },
+    moveToBody(event) {
+      let textarea = document.getElementsByTagName('textarea')[0]
+      let cursorPosition = textarea.selectionStart
+      if (event.target.value.length === cursorPosition) {
+        this.$emit('focus-trigger')
+      }
     }
   }
 }

--- a/app/components/organisms/ArticleEditor/NewArticleEditor.vue
+++ b/app/components/organisms/ArticleEditor/NewArticleEditor.vue
@@ -8,7 +8,7 @@
         />
       </div>
     </edit-header-nav>
-    <ArticleTitleInput v-model="title" />
+    <ArticleTitleInput v-model="title" v-on:focus-trigger="handleFocus" />
     <alis-editor
       style="position: relative;z-index: 1"
       @update="updateEditorState"
@@ -159,6 +159,10 @@ export default {
     },
     handleCloseModal() {
       this.isOpenModal = false
+    },
+    handleFocus() {
+      let alisEditor = document.getElementById('ALISEditor')
+      alisEditor.getElementsByClassName('target')[0].focus()
     },
     async updateEditorState(blocks) {
       if (this.isPublishing) return

--- a/app/components/organisms/ArticleEditor/NewArticleEditor.vue
+++ b/app/components/organisms/ArticleEditor/NewArticleEditor.vue
@@ -8,8 +8,9 @@
         />
       </div>
     </edit-header-nav>
-    <ArticleTitleInput v-model="title" v-on:focus-trigger="handleFocus" />
+    <ArticleTitleInput v-model="title" @focus-trigger="handleFocus" />
     <alis-editor
+      class="alis-editor"
       style="position: relative;z-index: 1"
       @update="updateEditorState"
       :initialState="blocks"
@@ -161,8 +162,8 @@ export default {
       this.isOpenModal = false
     },
     handleFocus() {
-      let alisEditor = document.getElementById('ALISEditor')
-      alisEditor.getElementsByClassName('target')[0].focus()
+      const alisEditor = this.$el.querySelector('.alis-editor')
+      alisEditor.querySelector('.target').focus()
     },
     async updateEditorState(blocks) {
       if (this.isPublishing) return


### PR DESCRIPTION
@y-temp4 

関係するタスク：
ALIS-2107, ALIS-2118

改修前：
タイトルのテキストエリアで改行を行う場合タイトル欄で改行が行われていた。またタイトルの文末でEnterを入力した場合にBody欄にカーソルが移動しなかった。

改修後：
タイトルの文章の途中でEnterを入力しても改行されない。また文末でEnterを入力した場合は改行され、記事入力欄にカーソルが移動する仕様にしました。