### PR TITLE
Install jest-transform-stub

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   moduleFileExtensions: ['js', 'json', 'vue'],
   transform: {
     '^.+\\.js$': '<rootDir>/node_modules/babel-jest',
+    '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
     '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest'
   },
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "jest": "^22.4.4",
+    "jest-transform-stub": "^1.0.0",
     "node-sass": "^4.7.2",
     "prettier": "^1.11.1",
     "prettier-eslint": "^8.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5290,6 +5290,11 @@ jest-snapshot@^22.4.0:
     natural-compare "^1.4.0"
     pretty-format "^22.4.3"
 
+jest-transform-stub@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-stub/-/jest-transform-stub-1.0.0.tgz#e4e941454f31a8bbc4db96b31f46a08b294372b1"
+  integrity sha512-7eilMk4sxi2Fiy223I+BYTS5wJQEGEBqR3D8dy5A6RWmMTnmjipw2ImGDfXzEUBieebyrnitzkJfpNOJSFklLQ==
+
 jest-util@^22.4.1, jest-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"


### PR DESCRIPTION
以前レビューで話が上がった Vue コンポーネント内で画像などを require したときの対処コードです。
`.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$` の regex にマッチするファイルについては、全て Jest 側で stub 化されるようになります。