### PR TITLE
ALIS-3112: Update exclude files

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,34 +20,15 @@ package:
     - LICENSE
     - README.md
     - package.json
+    - yarn-error.log
     - yarn.lock
-    - node_modules/@alisproject/dist/AlisEditor.common.js*
-    - node_modules/@alisproject/dist/AlisEditor.umd.js*
-    - node_modules/prettier-eslint/**
-    - node_modules/babel**/**
-    - node_modules/caniuse-db/**
-    - node_modules/prettier/**
-    - node_modules/yargs/**
-    - node_modules/typescript/**
-    - node_modules/postcss**/**
-    - node_modules/cssnano/**
-    - node_modules/xxhashjs/**
-    - node_modules/jschardet/**
-    - node_modules/inquirer/**
     - node_modules/**/*.md
     - node_modules/**/bin/**
   include:
     - app/static/part.js
     - server/**
-    - configs/**
     - nuxt.config.js
     - .nuxt/**
-    - node_modules/postcss/**
-    - node_modules/postcss-cssnext/**
-    - node_modules/postcss-import/**
-    - node_modules/postcss-import-resolver/**
-    - node_modules/postcss-loader/**
-    - node_modules/postcss-url/**
 
 functions:
   handler:

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,8 +22,6 @@ package:
     - package.json
     - yarn-error.log
     - yarn.lock
-    - node_modules/**/*.md
-    - node_modules/**/bin/**
   include:
     - app/static/part.js
     - server/**


### PR DESCRIPTION
## 概要
- `serverless.yml` でパッケージから除外していた `node_modules` 以下を削除
- `package:` の `excludeDevDependencies: true` を指定することにより、そもそも `devDependencies`の依存はパッケージングから除外できていた
- `exclude` から `node_modules` 以下のファイルを削除してもデプロイサイズ的に現状問題はない