### PR TITLE
ALIS-3238: Fix to check article.body

### DIFF
--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -201,7 +201,11 @@ const actions = {
   async getEditDraftArticle({ commit }, { articleId }) {
     try {
       const article = await this.$axios.$get(`/me/articles/${articleId}/drafts`)
-      const body = article.body.replace(/<p class=["|']paywall-line["|']>.*?<\/p>/, '')
+      // "/me/articles/drafts/article_id" への POST で記事が作成された直後、その記事データには body カラムがないため、
+      // article.body.replace がエラーとなってしまう。
+      // そこで、article.body の存在確認を行ってから article.body.replace の処理を行っている。
+      const body =
+        article.body && article.body.replace(/<p class=["|']paywall-line["|']>.*?<\/p>/, '')
       if (article.eye_catch_url) {
         commit(types.UPDATE_THUMBNAIL, { thumbnail: article.eye_catch_url })
       }

--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -204,6 +204,7 @@ const actions = {
       // "/me/articles/drafts/article_id" への POST で記事が作成された直後、その記事データには body カラムがないため、
       // article.body.replace がエラーとなってしまう。
       // そこで、article.body の存在確認を行ってから article.body.replace の処理を行っている。
+      // また、article.body.replace は有料記事本文に含まれる有料エリアを示すラインを削除する処理である。
       const body =
         article.body && article.body.replace(/<p class=["|']paywall-line["|']>.*?<\/p>/, '')
       if (article.eye_catch_url) {


### PR DESCRIPTION
## 概要
`article.body.replace`の処理の前に`article.body`があるかチェックする処理を追加した。
