### PR TITLE
ALIS-3655: Fix to check user auth status in mounted

### DIFF
--- a/app/pages/confirm.vue
+++ b/app/pages/confirm.vue
@@ -4,7 +4,7 @@
 
 <script>
 export default {
-  async created() {
+  async mounted() {
     const { code, user } = this.$route.query
     try {
       const result = await this.$store.dispatch('user/confirmEmail', { code, user })


### PR DESCRIPTION
## 概要
created 内で location を参照しているので、mounted を使うように修正（location はサーバーサイドで取得できず、本来はクライアントでのみ行いたい処理のため）