### PR TITLE
ALIS-3679: Fix not to reset tip articles

### DIFF
--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -1090,7 +1090,6 @@ const mutations = {
     state.page = 1
     state.isLastPage = false
     state.eyecatchArticles = []
-    state.tipEyecatchArticles = []
     state.recommendedArticles = {
       articles: [],
       page: 1,


### PR DESCRIPTION
## 概要

- トップからのページ遷移時に投げ銭によるオススメ記事の表示が消えないように修正
