### PR TITLE
Fix not to close login modal when access to pages that require authentication

### DIFF
--- a/app/components/molecules/LoginModalForm.vue
+++ b/app/components/molecules/LoginModalForm.vue
@@ -7,6 +7,7 @@
       <div v-show="isSelectedEmailAuth" class="email-auth" :class="{ isSelectedEmailAuth }">
         <form class="signup-form" @keypress.enter="onSubmit">
           <form-group
+            ref="userIdOrEmail"
             label="ユーザーID または メールアドレス"
             :inputAttrs="{ type: 'text', placeholder: 'alis@example.com' }"
             :hasError="hasUserIdOrEmailError"
@@ -15,6 +16,7 @@
             @focus="resetError('userIdOrEmail')"
           />
           <form-group
+            ref="password"
             label="パスワード※半角英数字8文字以上"
             :inputAttrs="{ ref: 'password', type: 'password', placeholder: '●●●●●●●●' }"
             :hasError="hasPasswordError"

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -49,7 +49,10 @@ export default {
     }
   },
   watch: {
-    $route() {
+    $route(to, from) {
+      // ログインが必要なページに遷移した場合、ユーザーにログインを求めるために
+      // ログインモーダルを表示する必要があるためモーダルを消す処理をスキップ
+      if (to.name === 'login') return
       this.$root.$emit('closeModal')
     }
   },


### PR DESCRIPTION
## 概要
- ログインが必要なページにアクセスした際、リダイレクトされログインのモーダルが一瞬表示されるが、すぐに消えてしまう。本来は表示したままが正しい挙動なので、消えないように修正

## 環境変数

- 環境変数に変更を加えたか否か
  - NO

## 影響範囲(システム)

* ログインが必要なページ（OAuthの認可画面など）

## 技術的変更点概要

現在、ページ遷移時にモーダルを消すロジックを加えていたが、これはログインが必要なページにアクセスしたときのことを考慮していなかった。

例えば、ログインしていない状態でOAuthの認可画面にアクセスすると、本来表示しておいてほしいログインのモーダルが消えてしまう。

そこで、リダイレクト先がログインモーダルだった場合、モーダルを非表示にしないようするロジックを追加した。

（その他の変更点は単純な記述漏れ）

## 使い方
ログインが必要なページ（例えば下書き記事画面など）に未ログイン状態でアクセスしてください。本番環境だと、ログインモーダルが表示されますがすぐに消えるはずです。

この変更を入れると、ログインモーダルが表示されたままになります。

## 個人情報やトークンの取り扱いに関係のある修正か
なし

## テスト結果とテスト項目

- [x] 未ログインの状態で下書き記事ページに遷移し、ログインモーダルが表示されたままになること
- [x] 未ログインの状態でOAuthの認可画面にアクセスし、ログインすると認可画面に戻ること


## 注意点・その他

buildのテストが落ちちゃってますが、lint-and-testは通っているので大丈夫かと思います🙏
