### PR TITLE
ALIS-3801: Fix bug that not load recommendedArticles for top.

### DIFF
--- a/app/components/molecules/DefaultHeaderNav.vue
+++ b/app/components/molecules/DefaultHeaderNav.vue
@@ -1,7 +1,7 @@
 <template>
   <nav class="area-nav">
     <div class="area-nav-links" @scroll="handleHorizontalScroll">
-      <nuxt-link to="/" class="nav-link area-topic0" @click.native="resetArticleData">
+      <nuxt-link to="/" class="nav-link area-topic0" @click.native="initTopPage">
         <span class="topic-display-name">
           オススメ
         </span>
@@ -75,6 +75,12 @@ export default {
     to(topic) {
       const to = this.articleType === 'popularArticles' ? 'popular' : 'recent'
       return { path: `/articles/${to}`, query: { topic } }
+    },
+    initTopPage() {
+      // 同一ページからの遷移の場合は記事の初期化は行わない
+      if (this.$route.path !== '/') {
+        this.resetArticleData()
+      }
     },
     resetData(event) {
       // 同一のページの場合は記事情報をリセットしない

--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -1140,6 +1140,9 @@ const mutations = {
     state.page = 1
     state.isLastPage = false
     state.eyecatchArticles = []
+    // fixme: 本来であれば tipEyecatchArticles も記事情報なので初期化すべきだが、
+    //        TOPページから他カテゴリに遷移する際に記事が何も表示されない状態となり、見栄えが悪いためコメントアウトしている。
+    // state.tipEyecatchArticles = []
     state.recommendedArticles = {
       articles: [],
       page: 1,


### PR DESCRIPTION
## 概要
トップページを表示したまま「オススメ」を押下すると、オススメ記事が全て消え更新されない状態となっていたため修正

## 技術的変更点概要
- 同一ページの場合は初期化処理を実施しないように修正
- 記事の初期化処理に tipEyecatchArticles が含まれていなかったため、対応しようとしたが表示崩れなどが発生したため fixme としてコメントした

