### PR TITLE
ALIS-4063: Fix a bug that comments are not displayed when reload.

### DIFF
--- a/app/components/organisms/ArticleComments.vue
+++ b/app/components/organisms/ArticleComments.vue
@@ -1,7 +1,8 @@
 <template>
   <div id="article-comments" class="area-article-comments">
-    <div class="header-contents">
+    <div class="area-header-contents">
       <span class="to-comment-button" @click="moveToBottom">コメントする</span>
+      <the-loader :is-loading="!article.initComment" class="comment-loader" />
       <span
         v-if="hasArticleCommentsLastEvaluatedKey"
         class="read-more-button"
@@ -17,10 +18,12 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import ArticleComment from '../atoms/ArticleComment'
+import TheLoader from '../atoms/TheLoader'
 
 export default {
   components: {
-    ArticleComment
+    ArticleComment,
+    TheLoader
   },
   props: {
     comments: {
@@ -35,7 +38,7 @@ export default {
   },
   computed: {
     ...mapGetters('user', ['loggedIn', 'currentUser']),
-    ...mapGetters('article', ['hasArticleCommentsLastEvaluatedKey'])
+    ...mapGetters('article', ['hasArticleCommentsLastEvaluatedKey', 'article'])
   },
   methods: {
     async showComments() {
@@ -86,28 +89,33 @@ export default {
   background-color: rgba(35, 37, 56, 0.05);
   display: grid;
   grid-area: article-comments;
-  padding: 20px calc(50% - 324px) 8px;
+  padding: 8px calc(50% - 324px) 8px;
 }
 
-.header-contents {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row-reverse;
-  padding: 20px 0 20px;
+.area-header-contents {
+  display: grid;
+  grid-template-columns: 110px 1fr 75px;
+  /* prettier-ignore */
+  grid-template-areas:
+    'read-more           loader           to-comment';
 }
 
 .read-more-button {
+  grid-area: read-more;
   color: #6e6e6e;
   cursor: pointer;
   font-size: 12px;
   font-weight: bold;
+  padding: 32px 0px 20px;
 }
 
 .to-comment-button {
+  grid-area: to-comment;
   color: #0086cc;
   cursor: pointer;
   font-size: 12px;
   font-weight: bold;
+  padding: 32px 0px 20px;
 }
 
 .article-comments {
@@ -117,7 +125,7 @@ export default {
 
 @media screen and (max-width: 640px) {
   .area-article-comments {
-    padding: 20px 10px 8px;
+    padding: 8px 10px 8px;
   }
 }
 </style>

--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -352,12 +352,12 @@ const actions = {
         article.user_id,
         articleId
       )
-      const [userInfo, alisToken, likesCount, comments] = await Promise.all([
+      const [userInfo, alisToken, likesCount] = await Promise.all([
         dispatch('getUserInfo', { userId: article.user_id }),
         dispatch('getAlisToken', { articleId }),
-        dispatch('getLikesCount', { articleId }),
-        dispatch('getArticleComments', { articleId })
+        dispatch('getLikesCount', { articleId })
       ])
+      const comments = []
       commit(types.SET_LIKES_COUNT, { likesCount })
       commit(types.SET_ARTICLE_DETAIL, {
         article: { ...article, body, userInfo, alisToken, comments }
@@ -375,12 +375,12 @@ const actions = {
       article.user_id,
       articleId
     )
-    const [userInfo, alisToken, likesCount, comments] = await Promise.all([
+    const [userInfo, alisToken, likesCount] = await Promise.all([
       dispatch('getUserInfo', { userId: article.user_id }),
       dispatch('getAlisToken', { articleId }),
-      dispatch('getLikesCount', { articleId }),
-      dispatch('getArticleComments', { articleId })
+      dispatch('getLikesCount', { articleId })
     ])
+    const comments = []
     commit(types.SET_LIKES_COUNT, { likesCount })
     commit(types.SET_ARTICLE_DETAIL, {
       article: { ...article, body, userInfo, alisToken, comments }
@@ -963,12 +963,12 @@ const actions = {
   async getPurchaedArticleDetail({ commit, dispatch }, { articleId }) {
     try {
       const article = await this.$axios.$get(`/api/me/articles/purchased/${articleId}`)
-      const [userInfo, alisToken, likesCount, comments] = await Promise.all([
+      const [userInfo, alisToken, likesCount] = await Promise.all([
         dispatch('getUserInfo', { userId: article.user_id }),
         dispatch('getAlisToken', { articleId }),
-        dispatch('getLikesCount', { articleId }),
-        dispatch('getArticleComments', { articleId })
+        dispatch('getLikesCount', { articleId })
       ])
+      const comments = []
       commit(types.SET_LIKES_COUNT, { likesCount })
       commit(types.SET_ARTICLE_DETAIL, { article: { ...article, userInfo, alisToken, comments } })
       commit(types.SET_IS_FETCHED_PURCHASED_ARTICLE, { isFetched: true })

--- a/app/store/modules/article.js
+++ b/app/store/modules/article.js
@@ -1249,6 +1249,7 @@ const mutations = {
   },
   [types.SET_ARTICLE_COMMENTS](state, { comments }) {
     state.article.comments.push(...comments)
+    state.article.initComment = true
   },
   [types.SET_ARTICLE_COMMENTS_LAST_EVALUATED_KEY](state, { lastEvaluatedKey }) {
     state.articleCommentsLastEvaluatedKey = lastEvaluatedKey


### PR DESCRIPTION
## 概要
- コメント記載後リロードを行った際、記載したコメントが表示されないケースがあった。これはコメント取得が SSR によって行われており cloudfront のキャッシュ（2分）が影響していたため。
この問題を解決するため、コメント取得を全てクライアント側で処理するように修正。

## 技術的変更点概要
- 既存の記事表示処理では記事情報取得に合わせてコメント情報も取得していたが、コメント情報は別途クライアント側で取得するように修正
