### PR TITLE
ALIS-4867: Remove webkit-box from notification card.

### DIFF
--- a/app/components/atoms/NotificationCardContentDescription.vue
+++ b/app/components/atoms/NotificationCardContentDescription.vue
@@ -75,10 +75,7 @@ export default {
 
 <style lang="scss" scoped>
 .area-description {
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
   color: #7f7f7f;
-  display: -webkit-box;
   font-size: 14px;
   line-height: 1.5;
   margin: 0;


### PR DESCRIPTION
## 概要
- お知らせで、文章量が２行を超える場合、末尾が「...」で省略される状態になっていたため、その処理を削除

## 技術的変更点概要
- 「webkit-box」を利用して意図的に末尾を省略する処理が入っていたが、バージョンアップ前の状態では「webkit-box-orient: vertical」が反映されておらず上手く機能していない状態だった（このため省略されていない状態だった）。バージョンアップにより該当処理が利用される状態になったが、末尾の省略処理自体が現状の運用上不要であるため、該当処理を削除