### PR TITLE
ALIS-4886: Add parameter of callbackWaitsForEmptyEventLoop.

### DIFF
--- a/server/handler.js
+++ b/server/handler.js
@@ -25,6 +25,8 @@ module.exports.handler = (event, context, callback) => {
       body: '',
       isBase64Encoded: false
     }
+    // 待機中のイベントがあっても処理を中断
+    context.callbackWaitsForEmptyEventLoop = false
     callback(null, response)
   } else {
     awsServerlessExpress.proxy(server, event, context)


### PR DESCRIPTION
callback 処理時にタイムアウトするケースがあったため、待機中のイベントがあっても強制的に処理を終了させるように改修