### PR TITLE
Fix css for tip ranking

### DIFF
--- a/app/components/pages/TipRanking.vue
+++ b/app/components/pages/TipRanking.vue
@@ -227,9 +227,9 @@ export default {
   }
 }
 
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 360px) {
   .tip-ranking-container {
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    grid-template-columns: minmax(10px, 1fr) auto minmax(10px, 1fr);
   }
 }
 </style>


### PR DESCRIPTION
## 概要

- 投げ銭ランキングページをスマホで表示した場合左によるケースが確認できたため修正
