### PR TITLE
ALIS-5266: Fix expire logic for localstorage.

### DIFF
--- a/app/utils/wallet.js
+++ b/app/utils/wallet.js
@@ -87,7 +87,7 @@ export function getLocalStoragePbkdf2Key() {
     return null
   }
   const now = new Date()
-  if (item.expire < now.getTime()) {
+  if (JSON.parse(item).expire < now.getTime()) {
     localStorage.removeItem('alis.to.wallet.pbkdf2Key')
     return null
   }


### PR DESCRIPTION
## 概要

- localstorage の expire 処理に不備があったため修正


## 技術的変更点概要

- JSON.parse をしておらず希望する値を取得できていなかった


