### PR TITLE
ALIS-5485 Add Cache-Control metadata to nuxt resources

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ DIST_S3_BUCKET_NAME=`aws ssm get-parameter --name ${ALIS_APP_ID}ssmDistS3BucketN
 export DIST_S3_BUCKET_NAME=${DIST_S3_BUCKET_NAME}
 
 # リソースをS3へアップロード
-aws s3 cp .nuxt/dist/client s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist --recursive
+aws s3 cp .nuxt/dist/client s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist --recursive --cache-control "public, max-age=31536000" --metadata-directive REPLACE
 aws s3 cp app/static/favicon.ico s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist/
 aws s3 cp app/static/OGP_1200×630.png s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist/
 aws s3 cp app/static/icon_user_noimg.png s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist/

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ DIST_S3_BUCKET_NAME=`aws ssm get-parameter --name ${ALIS_APP_ID}ssmDistS3BucketN
 export DIST_S3_BUCKET_NAME=${DIST_S3_BUCKET_NAME}
 
 # リソースをS3へアップロード
-aws s3 cp .nuxt/dist/client s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist --recursive --cache-control "public, max-age=31536000" --metadata-directive REPLACE
+aws s3 cp .nuxt/dist/client s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist --recursive --cache-control "public, max-age=86400" --metadata-directive REPLACE
 aws s3 cp app/static/favicon.ico s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist/
 aws s3 cp app/static/OGP_1200×630.png s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist/
 aws s3 cp app/static/icon_user_noimg.png s3://${DIST_S3_BUCKET_NAME}/d/nuxt/dist/


### PR DESCRIPTION
内容をご確認頂き、マージをお願いします（ステージングで動作確認済みです）。

【変更内容】
ブラウザキャッシュを効果的に活用するため、Nuxtのビルド成果物に対してキャッシュの指定を追加しました。
Nuxtのビルド成果物は全てファイル名にハッシュ値が含まれておりファイルが更新されることが無いため、キャッシュ時間は最大値を設定しています。
