### PR TITLE
Fix design of topics navigation

### DIFF
--- a/app/components/molecules/DefaultHeaderNav.vue
+++ b/app/components/molecules/DefaultHeaderNav.vue
@@ -242,7 +242,7 @@ $topicCount: 10;
     box-shadow: 0 0 0 1px #fff, 0 0 0 3px #0086cc;
     display: block;
     height: 44px;
-    margin: 3px 2px 0 2px;
+    margin: 3px 3px 0;
     width: 85px;
 
     .topic-display-name {
@@ -251,6 +251,15 @@ $topicCount: 10;
 
     &:before {
       background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.5) 100%);
+    }
+
+    &:after {
+      position: absolute;
+      top: 0;
+      left: 100%;
+      width: 3px;
+      height: 1px;
+      content: '';
     }
 
     &.area-topic0 {


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->

## 概要

トピックの選択時とスクロールの最後の部分で、微妙に枠線が細くなっている箇所を修正しました 🙌

### Before

![スクリーンショット 2020-10-27 10 59 04](https://user-images.githubusercontent.com/13657589/97287204-a4d4e780-1887-11eb-88c2-59cf4e1b6546.png)
![スクリーンショット 2020-10-27 10 59 16](https://user-images.githubusercontent.com/13657589/97287207-a6061480-1887-11eb-816d-52b5c0f1a286.png)

### After

![スクリーンショット 2020-10-27 11 05 06](https://user-images.githubusercontent.com/13657589/97287222-aa323200-1887-11eb-812d-f332ad0b8aee.png)
![スクリーンショット 2020-10-27 11 05 19](https://user-images.githubusercontent.com/13657589/97287224-ab635f00-1887-11eb-8ba1-b2a313ab5437.png)

## SSM・環境変数

- SSM に変更を加えたか否か
  - NO
- 環境変数に変更を加えたか否か(注：原則として SSM を使用し、環境変数は使用しない)
  - NO

## 影響範囲(システム)

トピックの表示箇所

## 技術的変更点概要

CSS の margin のスクロール時のスペースの挙動を修正しました。

## テスト結果とテスト項目

以下の環境で表示を確認しています。

- macOS Chrome
- macOS Safari
- iPhone11 Safari

## レビュワーに依頼したいこと

- 表示が崩れていないことを確認していただきたいです

## その他

- CI まわせないのはすみません😇