### PR TITLE
Fix cls for figure content.

### DIFF
--- a/app/components/pages/ArticleDetailV2.vue
+++ b/app/components/pages/ArticleDetailV2.vue
@@ -534,6 +534,9 @@ header.area-app-header {
         }
       }
     }
+    figure {
+      min-height: 140px;
+    }
   }
 }
 


### PR DESCRIPTION

## 概要
- 埋め込みタグが表示される際のブレを低減

## 技術的変更点概要

- iframely で表示する際、リンクの内容により height が異なっているためあらかじめ予測することが難しい。このため最低限利用する height についてはあらかじめ確保しておきブレを低減